### PR TITLE
remove lodash dependency.

### DIFF
--- a/lib/x-error.js
+++ b/lib/x-error.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 
 module.exports = (function() {
   var xError = function xError(code, message, data) {
@@ -56,8 +55,12 @@ module.exports = (function() {
     	source.message && (this.message = source.message);
     	source.stack = (this.stack = source.stack);
     }
-    
-    return _.assign(this, source || {});
+
+    source = source || {};
+    for (var key in source) {
+      this[key] = source[key];
+    }
+    return this;
   };
   xError.prototype.debug = function(data){
     if (!this._debug) this._debug = [];

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "type": "git",
     "url": "https://github.com/yzarubin/x-error.git"
   },
-  "dependencies": {
-    "lodash": "2.4.x"
-  },
   "devDependencies": {
     "chai": "~1.9.0",
     "mocha": "~1.17.0",


### PR DESCRIPTION
Lifted off `lodash` dependency.
Users may end up with 5-10 different lodash versions in a medium-sized project (since a _lot_ of modules depend on it).

Since this module only has 1 call to it, I would remove it, for now. It might be included again in case there is necessity!
